### PR TITLE
UI to stderr - Easier to capture output. Also -W / --no-wipe, and UI help line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,14 @@ $ clid
 # Same as before but output in cmyk format.
 $ clid --format=cmyk
 
-# This is an example how to pipe the output of clid into wl-copy
-$ ./clid --format=hex | tee /dev/tty | tail -n 1 | wl-copy
+# You can pipe the output into your clipboard:
+$ ./clid --format=hex | wl-copy            # For Weyland
+$ ./clid --format=hex | xsel -i -b         # For X11
+$ ./clid --format=hex | xclip -i -sel clip # For X11
+
+# Or capture it in a variable (you can add options here as well, like ./clid -W):
+$ color=$(./clid)             # Preferred.
+$ read -r color < <(./clid)   # Works in bash, ksh, zsh, ..., but **not sh**
 
 # Use --help to get a list of all arguments and view tui inputs.
 $ clid --help

--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -40,17 +40,24 @@ std::unordered_map<std::string, std::string> Utility::ParseArgs(int argc, char* 
 
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
+        size_t prefixLen = 0;
 
         if (arg.rfind("--", 0) == 0) {  // starts with "--"
+            prefixLen = 2;
+        } else if (arg.rfind("-", 0) == 0) { // starts with "-"
+            prefixLen = 1;
+        }
+
+        if (prefixLen > 0) {
             size_t eqPos = arg.find('=');
             if (eqPos != std::string::npos) {
                 // Format: --key=value
-                std::string key = arg.substr(2, eqPos - 2);
+                std::string key = arg.substr(prefixLen, eqPos - prefixLen);
                 std::string value = arg.substr(eqPos + 1);
                 args[key] = value;
             } else {
                 // Flag without value
-                std::string key = arg.substr(2);
+                std::string key = arg.substr(prefixLen);
                 args[key] = "";  // empty value
             }
         }
@@ -82,4 +89,12 @@ bool Utility::StringToUint8(const std::string& str, uint8_t& out) {
     } catch (const std::exception& e) {
         return false;
     }
+}
+
+void Utility::CursorDown(std::ostream& stream, size_t lines) {
+    stream << "\033[" << lines << "B";
+}
+
+void Utility::CursorPos(std::ostream& stream, size_t row, size_t col) {
+    stream << "\033[" << row << ";" << col << "H";
 }

--- a/src/Utility.h
+++ b/src/Utility.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <cstdint>
 #include <vector>
+#include <iostream>
 
 namespace Utility {
 
@@ -12,6 +13,12 @@ namespace Utility {
 
     /** Count howmany lines a string has. */
     size_t CountLines(const std::string& str);
+
+    /** Move the cursor down n lines */
+    void CursorDown(std::ostream& stream, size_t lines);
+
+    /** Move the cursor to a specific row and column. */
+    void CursorPos(std::ostream& stream, size_t row, size_t col);
 
     /** Parse commandline arguments to be easyer to handle */
     std::unordered_map<std::string, std::string> ParseArgs(int argc, char* argv[]);


### PR DESCRIPTION
Most important change:
 - Changed all UI output to stderr so the final color code is easier to capture.

Other changes:
 - Added example usage to -h / --help
 - Allow -options for shorthand (- and -- are accepted for all).
 - Added -W / --no-wipe to prevent wiping of UI
 - Dark quick help line in UI to help in user-adoption
